### PR TITLE
Fix visualizer constantly giving internet connection error

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -21,7 +21,7 @@ export default function App() {
 
 	useEffect(() => {
 		const updatePlayerState = async (newState: Spicetify.PlayerState) => {
-			const item = newState?.item ?? newState?.track;
+			const item = newState?.item ?? newState?.item;
 
 			if (!item) {
 				setState(VisualizerState.ERROR_NOT_PLAYING);
@@ -36,9 +36,10 @@ export default function App() {
 
 			setState(VisualizerState.LOADING);
 
+			const trackId = Spicetify.URI.fromString(uri).id;
 			const [audioAnalysis, vibrantColor] = await Promise.all([
-				Spicetify.getAudioData(uri).catch(() => undefined) as Promise<SpotifyAudioAnalysis | undefined>,
-				Spicetify.extractColorPreset(item.metadata.image_url).then(colors => colors[0].colorLight)
+				Spicetify.CosmosAsync.get(`https://api.spotify.com/v1/audio-analysis/${trackId}`).catch((err) => console.log(err)) as Promise<SpotifyAudioAnalysis | undefined>,
+				Spicetify.extractColorPreset(item.metadata.image_url).then(colors => colors[0].colorLight).catch((err) => console.log(err))
 			]);
 
 			if (!audioAnalysis) {

--- a/src/types/spicetify.d.ts
+++ b/src/types/spicetify.d.ts
@@ -190,10 +190,6 @@ declare namespace Spicetify {
 		playbackId: string;
 		sessionId: string;
 		signals?: any[];
-		/**
-		 * @deprecated Use `item` instead. This will be removed in the future.
-		 */
-		track: PlayerTrack;
 	};
 	type PlayerContext = {
 		uri: string;
@@ -1766,7 +1762,7 @@ declare namespace Spicetify {
 			/**
 			 * React component to render for an icon used as button body. Component, not element!
 			 */
-			iconTrailing?: (props: any) => any | string;
+			iconOnly?: (props: any) => any | string;
 			/**
 			 * Additional class name to apply to the button.
 			 */
@@ -1774,11 +1770,11 @@ declare namespace Spicetify {
 			/**
 			 * Label of the element for screen readers.
 			 */
-			["aria-label"]?: string;
+			"aria-label"?: string;
 			/**
 			 * ID of an element that describes the button for screen readers.
 			 */
-			["aria-labelledby"]?: string;
+			"aria-labelledby"?: string;
 			/**
 			 * Unsafely set the color set for the button.
 			 * Values from the colorSet will be pasted into the CSS.
@@ -1895,6 +1891,27 @@ declare namespace Spicetify {
 		 * @see Spicetify.ReactComponent.SliderProps
 		 */
 		const Slider: any;
+		/**
+		 * Component to render Spotify primary button
+		 *
+		 * Props:
+		 * @see Spicetify.ReactComponent.ButtonProps
+		 */
+		const ButtonPrimary: any;
+		/**
+		 * Component to render Spotify secondary button
+		 *
+		 * Props:
+		 * @see Spicetify.ReactComponent.ButtonProps
+		 */
+		const ButtonSecondary: any;
+		/**
+		 * Component to render Spotify tertiary button
+		 *
+		 * Props:
+		 * @see Spicetify.ReactComponent.ButtonProps
+		 */
+		const ButtonTertiary: any;
 	}
 
 	/**


### PR DESCRIPTION
The `getAudioData` function from Spicetify doesn't work anymore, so as a temporary workaround, I changed it to use the normal API from spotify to get the analyzer data.